### PR TITLE
fix: make slugs required

### DIFF
--- a/sanity/schemas/article.tsx
+++ b/sanity/schemas/article.tsx
@@ -39,6 +39,7 @@ export const article = defineType({
       type: 'slug',
       title: 'Slug',
       options: { source: 'title' },
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       name: 'coverImage',

--- a/sanity/schemas/resource.ts
+++ b/sanity/schemas/resource.ts
@@ -34,6 +34,7 @@ export const resource = defineType({
       type: 'slug',
       title: 'Slug',
       options: { source: 'title' },
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       name: 'type',


### PR DESCRIPTION
Make `slug` field required in `article` & `resource` schema